### PR TITLE
Fix the cludod health endpoint

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,6 +8,8 @@ All public SuperOrbital helm charts should be maintained in this repo.
     * You need to modify [ArtifactHub's metadata file](https://github.com/superorbital/helm-charts/blob/gh-pages/artifacthub-repo).
   * Anything merged into main will be published to the public repo.
 
+When making changes to a chart, **ALWAYS** make sure that you update the `version` field in the `Chart.yaml` file. If this chart will also deploy a newer version of the application, you **MUST** also update the `appVersion` field in the `Chart.yaml` file.
+
 ## Github Actions
 
 ### CI Pipeline (`ci.yaml`)

--- a/charts/cludod/Chart.yaml
+++ b/charts/cludod/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cludod/templates/cludod-deployment.yaml
+++ b/charts/cludod/templates/cludod-deployment.yaml
@@ -36,11 +36,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /v1/health
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /v1/health
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
This updates the `cludod` helm chart to use the correct health check endpoint.